### PR TITLE
updated deps and retrofited to new apis

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 name: Rust
 
@@ -50,6 +54,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: -- --nocapture
         env:
           NATS_PATH: ./nats-server-v2.1.2-linux-amd64/nats-server
 
@@ -57,7 +62,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features native-tls
+          args: --features native-tls -- --nocapture
         env:
           NATS_PATH: ./nats-server-v2.1.2-linux-amd64/nats-server
 
@@ -65,7 +70,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features rustls-tls
+          args: --features rustls-tls -- --nocapture
         env:
           NATS_PATH: ./nats-server-v2.1.2-linux-amd64/nats-server
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,29 +14,30 @@ exclude = ["rust-toolchain", ".vscode"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytes = "0.5.1"
-futures = "0.3.1"
-log = "0.4.8"
-nom = "5.0.1"
-owning_ref = "0.4.0"
-pin-project = "0.4.17"
-rand = "0.7.2"
-serde = { version = "1.0.101", features = ["derive"] }
-serde_json = "1.0.40"
-tokio = { version = "0.2.1", features = ["dns", "io-util", "macros", "stream", "sync", "rt-core", "time", "tcp"] }
-tokio-util = { version = "0.2.0", features = ["codec"] }
-uuid = { version = "0.7.4", features = ["v4"] }
+bytes = "*"
+futures = "*"
+log = "*"
+nom = "*"
+owning_ref = "*"
+pin-project = "*"
+rand = "*"
+serde = { version = "*", features = ["derive"] }
+serde_json = "*"
+tokio = { version = "*", features = ["io-util", "macros", "sync", "time", "net"] }
+tokio-util = { version = "*", features = ["codec"] }
+tokio-stream = { version = "*", features = ["sync"] }
+uuid = { version = "*", features = ["v4"] }
 
 # Optional dependencies
-native-tls-crate = { version = "0.2.3", optional = true, package = "native-tls" }
-rustls = { version = "0.18.1", optional = true }
-tokio-native-tls = { version = "0.1.0", optional = true }
-tokio-rustls = { version = "0.14.1", optional = true }
+native-tls-crate = { version = "*", optional = true, package = "native-tls" }
+rustls = { version = "*", optional = true }
+tokio-native-tls = { version = "*", optional = true }
+tokio-rustls = { version = "*", optional = true }
 
 [dev-dependencies]
-env_logger = "0.6.2"
-hostname = "0.2.0"
-tokio = { version = "0.2.1", features = ["process"] }
+env_logger = "*"
+hostname = "*"
+tokio = { version = "*", features = ["process", "rt-multi-thread"] }
 
 [features]
 default = []

--- a/src/tls_or_tcp_stream.rs
+++ b/src/tls_or_tcp_stream.rs
@@ -9,7 +9,7 @@ use std::{
     task::{Context, Poll},
 };
 use tokio::{
-    io::{self, AsyncRead, AsyncWrite},
+    io::{self, AsyncRead, AsyncWrite, ReadBuf},
     net::TcpStream,
 };
 
@@ -43,8 +43,8 @@ impl AsyncRead for TlsOrTcpStream {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context,
-        buf: &mut [u8],
-    ) -> Poll<io::Result<usize>> {
+        buf: &mut ReadBuf,
+    ) -> Poll<io::Result<()>> {
         match self.project() {
             TlsOrTcpStreamProj::TcpStream(stream) => stream.poll_read(cx, buf),
             #[cfg(feature = "tls")]

--- a/src/types/error.rs
+++ b/src/types/error.rs
@@ -47,7 +47,7 @@ pub enum Error {
     NotEnoughData,
     /// A timeout that has elapsed. For example: when a request does not a receive a response
     /// before the provided timeout duration has expired.
-    Timeout(time::Elapsed),
+    Timeout(time::error::Elapsed),
     /// Occurs when no TLS connector was specified, but the server requires a TLS connection.
     TlsDisabled,
     /// Occurs when trying to [`unsubscribe`](../struct.Client.html#method.unsubscribe) with
@@ -58,11 +58,7 @@ pub enum Error {
 impl Error {
     /// Returns true if the error is a `NotConnected` error
     pub fn not_connected(&self) -> bool {
-        if let Self::NotConnected = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, Self::NotConnected)
     }
 }
 
@@ -101,8 +97,8 @@ impl fmt::Display for Error {
 
 impl std::error::Error for Error {}
 
-impl From<tokio::time::Elapsed> for Error {
-    fn from(e: tokio::time::Elapsed) -> Self {
+impl From<tokio::time::error::Elapsed> for Error {
+    fn from(e: tokio::time::error::Elapsed) -> Self {
         Error::Timeout(e)
     }
 }

--- a/src/types/parser.rs
+++ b/src/types/parser.rs
@@ -8,7 +8,7 @@ use nom::{
     bytes::complete::{is_not, tag, tag_no_case, take_until},
     character::complete::{digit1, space1},
     combinator::{all_consuming, cut, map_res, opt},
-    multi::separated_nonempty_list,
+    multi::separated_list1,
     sequence::delimited,
     IResult,
 };
@@ -91,8 +91,7 @@ fn full_wildcard_subject(input: &str) -> IResult<&str, Subject> {
 }
 
 fn not_full_wildcard_subject(input: &str) -> IResult<&str, Subject> {
-    let (input, tokens) =
-        separated_nonempty_list(tag(util::SUBJECT_TOKEN_DELIMITER), token)(input)?;
+    let (input, tokens) = separated_list1(tag(util::SUBJECT_TOKEN_DELIMITER), token)(input)?;
     let (input, full_wildcard) = opt(trailing_full_wildcard)(input)?;
     let tokens = tokens.iter().map(|s| String::from(*s)).collect();
     let subject = Subject {

--- a/src/types/state.rs
+++ b/src/types/state.rs
@@ -20,6 +20,7 @@ pub enum ConnectionState {
 }
 
 #[derive(Debug)]
+#[allow(clippy::enum_variant_names)]
 pub enum StateTransition {
     ToConnecting(Address),
     ToConnected(WriteHalf<TlsOrTcpStream>),

--- a/tests/authorization_override.rs
+++ b/tests/authorization_override.rs
@@ -3,7 +3,7 @@ mod common;
 use common::NatsServer;
 use rants::Client;
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn authorization_override() {
     common::init();
     let _nats_server = NatsServer::new(&["--user=test", "--pass=not_secure="]).await;

--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -1,14 +1,13 @@
 mod common;
 
 use common::NatsServer;
-use futures::stream::StreamExt;
 use rants::Client;
 use tokio::runtime::Runtime;
 
 #[test]
 fn blocking() {
     common::init();
-    let mut rt = Runtime::new().unwrap();
+    let rt = Runtime::new().unwrap();
     let _nats_server = rt.block_on(NatsServer::new(&[]));
 
     let address = "127.0.0.1".parse().unwrap();
@@ -22,7 +21,7 @@ fn blocking() {
     let subject = "test".parse().unwrap();
     let (_, mut subscription) = rt.block_on(client.subscribe(&subject, 1)).unwrap();
     rt.block_on(client.publish(&subject, b"test")).unwrap();
-    let result = rt.block_on(subscription.next()).unwrap();
+    let result = rt.block_on(subscription.recv()).unwrap();
     assert_eq!(result.payload(), b"test");
 
     rt.block_on(client.disconnect());

--- a/tests/echo.rs
+++ b/tests/echo.rs
@@ -3,8 +3,9 @@ mod common;
 use common::NatsServer;
 use futures::{future, stream::StreamExt};
 use rants::Client;
+use tokio_stream::wrappers::ReceiverStream;
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn echo() {
     common::init();
     let _nats_server = NatsServer::new(&[]).await;
@@ -40,6 +41,7 @@ async fn echo() {
         .subscribe(&subject, number_of_messages)
         .await
         .unwrap();
+    let subscription = ReceiverStream::new(subscription);
 
     // Publish messages to "test" subscription
     let mut publishers = Vec::new();

--- a/tests/native_tls_connection.rs
+++ b/tests/native_tls_connection.rs
@@ -10,7 +10,7 @@ mod test {
     };
     use std::{fs::File, io::Read};
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn native_tls_connection() {
         common::init();
         let _nats_server = NatsServer::new(&[

--- a/tests/ping_pong.rs
+++ b/tests/ping_pong.rs
@@ -4,7 +4,7 @@ use common::NatsServer;
 use hostname;
 use rants::{Address, Client};
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn ping_pong() {
     common::init();
     let _nats_server = NatsServer::new(&["--port=5678"]).await;

--- a/tests/reconnect.rs
+++ b/tests/reconnect.rs
@@ -1,10 +1,9 @@
 mod common;
 
 use common::NatsServer;
-use futures::stream::StreamExt;
 use rants::Client;
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn reconnect() {
     common::init();
     let _nats_server = NatsServer::new(&[]).await;
@@ -19,13 +18,12 @@ async fn reconnect() {
 
     // Subscribe to the subject
     let (_, mut subscription) = client.subscribe(&subject, 4).await.unwrap();
-
     // Publish messages to the subject
     client.publish(&subject, &[1]).await.unwrap();
     client.publish(&subject, &[2]).await.unwrap();
 
-    assert_eq!(subscription.next().await.unwrap().into_payload(), &[1]);
-    assert_eq!(subscription.next().await.unwrap().into_payload(), &[2]);
+    assert_eq!(subscription.recv().await.unwrap().into_payload(), &[1]);
+    assert_eq!(subscription.recv().await.unwrap().into_payload(), &[2]);
 
     // Disconnect
     client.disconnect().await;
@@ -40,11 +38,11 @@ async fn reconnect() {
     client.publish(&subject, &[4]).await.unwrap();
     client.publish(&subject, &[5]).await.unwrap();
 
-    assert_eq!(subscription.next().await.unwrap().payload(), &[4]);
-    assert_eq!(subscription.next().await.unwrap().payload(), &[5]);
+    assert_eq!(subscription.recv().await.unwrap().payload(), &[4]);
+    assert_eq!(subscription.recv().await.unwrap().payload(), &[5]);
 
     client.disconnect().await;
     std::mem::drop(client);
 
-    assert!(subscription.next().await.is_none());
+    assert!(subscription.recv().await.is_none());
 }

--- a/tests/request.rs
+++ b/tests/request.rs
@@ -1,7 +1,6 @@
 mod common;
 
 use common::NatsServer;
-use futures::stream::StreamExt;
 use rants::{error::Error, Client, Subject};
 
 async fn make_subscription(client: Client, subject: &Subject) {
@@ -9,7 +8,7 @@ async fn make_subscription(client: Client, subject: &Subject) {
     let client_copy = Client::clone(&client);
     tokio::spawn(async move {
         // Wait for the request
-        let request = subscription.next().await.unwrap();
+        let request = subscription.recv().await.unwrap();
         let reply_to = request.reply_to().unwrap().clone();
         let request = String::from_utf8(request.into_payload()).unwrap();
         assert_eq!(&request, "the request");
@@ -19,7 +18,7 @@ async fn make_subscription(client: Client, subject: &Subject) {
     });
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn request() {
     common::init();
     let _nats_server = NatsServer::new(&["--auth=abc123"]).await;

--- a/tests/rustls_tls_connection.rs
+++ b/tests/rustls_tls_connection.rs
@@ -7,7 +7,7 @@ mod test {
     use rants::{rustls::ClientConfig, Client};
     use std::{fs::File, io::BufReader};
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn rustls_tls_connection() {
         common::init();
         let _nats_server = NatsServer::new(&[


### PR DESCRIPTION
Note that this also addresses a thread deadlocking issue that may or may not have been triggered by the bumped crate refactoring. The `disconnecting` method now takes the WatchStream instead of the wrapped_client. Locking the client in the future was holding the lock and blocking other threads.

Signed-off-by: Matt Wrock <matt@mattwrock.com>